### PR TITLE
Replace .value with SetValueWithoutNotify

### DIFF
--- a/UnityEngine.UI/UI/Core/ScrollRect.cs
+++ b/UnityEngine.UI/UI/Core/ScrollRect.cs
@@ -882,7 +882,7 @@ namespace UnityEngine.UI
                 else
                     m_HorizontalScrollbar.size = 1;
 
-                m_HorizontalScrollbar.value = horizontalNormalizedPosition;
+                m_HorizontalScrollbar.SetValueWithoutNotify(horizontalNormalizedPosition);
             }
 
             if (m_VerticalScrollbar)
@@ -892,7 +892,7 @@ namespace UnityEngine.UI
                 else
                     m_VerticalScrollbar.size = 1;
 
-                m_VerticalScrollbar.value = verticalNormalizedPosition;
+                m_VerticalScrollbar.SetValueWithoutNotify(verticalNormalizedPosition);
             }
         }
 


### PR DESCRIPTION
When I test a scroll rect with a extremely long content on a height screen(>= 18:9) mobile, I encountered a bug that the scroll view always stop immediately without any inertia. This pr can fix it. It is not correct to change ScrollBar's value with notify from UpdateScrollbars method. 