### PR TITLE
Add inertia velocity multipler to ScrollRect

### DIFF
--- a/UnityEditor.UI/UI/ScrollRectEditor.cs
+++ b/UnityEditor.UI/UI/ScrollRectEditor.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.UI
         SerializedProperty m_MovementType;
         SerializedProperty m_Elasticity;
         SerializedProperty m_Inertia;
+        SerializedProperty m_InertiaVelocityMultiplier;
         SerializedProperty m_DecelerationRate;
         SerializedProperty m_ScrollSensitivity;
         SerializedProperty m_Viewport;
@@ -42,6 +43,7 @@ namespace UnityEditor.UI
             m_MovementType          = serializedObject.FindProperty("m_MovementType");
             m_Elasticity            = serializedObject.FindProperty("m_Elasticity");
             m_Inertia               = serializedObject.FindProperty("m_Inertia");
+            m_InertiaVelocityMultiplier     = serializedObject.FindProperty("m_InertiaVelocityMultiplier");
             m_DecelerationRate      = serializedObject.FindProperty("m_DecelerationRate");
             m_ScrollSensitivity     = serializedObject.FindProperty("m_ScrollSensitivity");
             m_Viewport              = serializedObject.FindProperty("m_Viewport");
@@ -121,6 +123,7 @@ namespace UnityEditor.UI
             if (EditorGUILayout.BeginFadeGroup(m_ShowDecelerationRate.faded))
             {
                 EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(m_InertiaVelocityMultiplier);
                 EditorGUILayout.PropertyField(m_DecelerationRate);
                 EditorGUI.indentLevel--;
             }

--- a/UnityEngine.UI/UI/Core/ScrollRect.cs
+++ b/UnityEngine.UI/UI/Core/ScrollRect.cs
@@ -255,7 +255,7 @@ namespace UnityEngine.UI
         /// }
         /// </code>
         /// </example>
-        public float inertiaVelocityMultiplier => m_InertiaVelocityMultiplier;
+        public float inertiaVelocityMultiplier { get => m_InertiaVelocityMultiplier; set => m_InertiaVelocityMultiplier = value; }
 
         [SerializeField]
         private float m_DecelerationRate = 0.135f; // Only used when inertia is enabled

--- a/UnityEngine.UI/UI/Core/ScrollRect.cs
+++ b/UnityEngine.UI/UI/Core/ScrollRect.cs
@@ -222,9 +222,6 @@ namespace UnityEngine.UI
         [SerializeField]
         private bool m_Inertia = true;
 
-        [SerializeField]
-        private float m_InertiaVelocityMultiplier = 10f;
-
         /// <summary>
         /// Should movement inertia be enabled?
         /// </summary>
@@ -232,6 +229,33 @@ namespace UnityEngine.UI
         /// Inertia means that the scrollrect content will keep scrolling for a while after being dragged. It gradually slows down according to the decelerationRate.
         /// </remarks>
         public bool inertia { get { return m_Inertia; } set { m_Inertia = value; } }
+
+        [SerializeField]
+        private float m_InertiaVelocityMultiplier = 10f; // Only used when inertia is enabled
+
+        /// <summary>
+        /// Multiplier of the velocity when moving due to inertia.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// using UnityEngine;
+        /// using System.Collections;
+        /// using UnityEngine.UI; // Required when Using UI elements.
+        ///
+        /// public class ExampleClass : MonoBehaviour
+        /// {
+        ///     public ScrollRect myScrollRect;
+        ///
+        ///     public void Start()
+        ///     {
+        ///         // assigns a new value to the inertiaVelocityMultiplier of the scroll rect.
+        ///         // The higher the number the faster the initial speed.
+        ///         myScrollRect.inertiaVelocityMultiplier = 5.0f;
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public float inertiaVelocityMultiplier => m_InertiaVelocityMultiplier;
 
         [SerializeField]
         private float m_DecelerationRate = 0.135f; // Only used when inertia is enabled

--- a/UnityEngine.UI/UI/Core/ScrollRect.cs
+++ b/UnityEngine.UI/UI/Core/ScrollRect.cs
@@ -222,6 +222,9 @@ namespace UnityEngine.UI
         [SerializeField]
         private bool m_Inertia = true;
 
+        [SerializeField]
+        private float m_InertiaVelocityMultiplier = 10f;
+
         /// <summary>
         /// Should movement inertia be enabled?
         /// </summary>
@@ -846,7 +849,7 @@ namespace UnityEngine.UI
             if (m_Dragging && m_Inertia)
             {
                 Vector3 newVelocity = (m_Content.anchoredPosition - m_PrevPosition) / deltaTime;
-                m_Velocity = Vector3.Lerp(m_Velocity, newVelocity, deltaTime * 10);
+                m_Velocity = Vector3.Lerp(m_Velocity, newVelocity, deltaTime * m_InertiaVelocityMultiplier);
             }
 
             if (m_ViewBounds != m_PrevViewBounds || m_ContentBounds != m_PrevContentBounds || m_Content.anchoredPosition != m_PrevPosition)


### PR DESCRIPTION
Increasing the inertia velocity multiplier is essential to make scrolling through lots of content feel good on a touch screen.