### PR TITLE
Fix issue where a Selectable component remains highlighted when the cursor leaves it while input is DOWN

### DIFF
--- a/UnityEngine.UI/UI/Core/Selectable.cs
+++ b/UnityEngine.UI/UI/Core/Selectable.cs
@@ -583,7 +583,7 @@ namespace UnityEngine.UI
             {
                 if (!IsInteractable())
                     return SelectionState.Disabled;
-                if (isPointerDown)
+                if (isPointerDown && isPointerInside)
                     return SelectionState.Pressed;
                 if (hasSelection)
                     return SelectionState.Selected;


### PR DESCRIPTION
> I don't expect this even to be taken in, but hay ho.

Resolves an issue where a Selectable control will remain in a highlighted state if a user is holding input while they move the cursor from the bounds of the Selectable.

Currently, this leaves a button in a "Highlighted" state simply because it only checks if the Pointer is down and NOT if the pointer is within the bounds of the control.

The fix simply checks BOTH the Pointer down state and the Pointer Inside state before marking a selectable as highlighted.
